### PR TITLE
Fix: Prevent IndexError in player idle animation

### DIFF
--- a/main.py
+++ b/main.py
@@ -265,6 +265,8 @@ class Player(pygame.sprite.Sprite):
                 frame = self.walk_frames[0]
                 self.current_frame = 0  # 静止时重置帧索引
             else:
+                if self.current_frame >= len(self.idle_frames):
+                    self.current_frame = 0
                 self.frame_timer += 1 / FPS
                 # 闲置动画使用自己的帧间隔
                 if self.frame_timer >= self.idle_frame_interval:  # 使用 idle_frame_interval


### PR DESCRIPTION
The `Player._update_alive_image` method could raise an IndexError when a player (specifically player 2, the "witch") transitioned from moving to idle. This occurred if `self.current_frame`, previously updated based on `self.walk_frames`, was out of bounds for the potentially shorter `self.idle_frames` list.

The fix adds a check within the idle animation logic. If `self.idle_frames` are being used, it verifies if
`self.current_frame` is a valid index for `self.idle_frames`. If not (i.e., `self.current_frame >= len(self.idle_frames)`), `self.current_frame` is reset to 0 before it's used to access the `self.idle_frames` list. This ensures that the index is always valid, preventing the crash.

Lengths of animation lists from animations.py:
- Player 2 (witch) walk_frames: 8
- Player 2 (witch) idle_frames: 6 The error happened when current_frame was >= 6 upon entering idle state.